### PR TITLE
Add RL training scripts and reward services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,25 @@
 .idea/
+
+# Python and local environments
+__pycache__/
+*.py[cod]
+.venv/
+.env
+.env.*
+!.env.example
+
+# Training artifacts and caches
+.cache/
+outputs/
+checkpoints/
+logs/
+wandb/
+merged_hf_step*/
+
+# Datasets and model weights
+*.parquet
+*.safetensors
+pytorch_model*.bin
+*.ckpt
+*.pt
+*.pth

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ print(tokenizer.decode(outputs[0], skip_special_tokens=True))
 
 ## 🏋️ Training
 
-We train our models with the [LlamaFactory](https://github.com/hiyouga/LlamaFactory) framework. See the [LlamaFactory data docs](https://github.com/hiyouga/LlamaFactory/tree/main/data) for how to register pretraining and finetuning datasets. Remember to add your dataset to `dataset_info.json` before training.
+We use [LlamaFactory](https://github.com/hiyouga/LlamaFactory) for continual pretraining and supervised finetuning. See the [LlamaFactory data docs](https://github.com/hiyouga/LlamaFactory/tree/main/data) for how to register those datasets. Remember to add your dataset to `dataset_info.json` before training.
 
 ### Continual Pretraining
 
@@ -122,6 +122,16 @@ Data samples for translation instruction finetuning are in [`examples/sft.json`]
 bash scripts/sft.sh
 ```
 
+### Reinforcement Learning and Model Merging
+
+MiLMMT-46-v1.0 adds GRPO fine-tuning with [verl](https://github.com/volcengine/verl), exports the resulting FSDP actor checkpoint to Hugging Face format, and linearly interpolates the SFT and RL weights.
+
+- GRPO launcher and reward client: [`scripts/rl/run_grpo.sh`](scripts/rl/run_grpo.sh)
+- Batched xCOMET/OpenLID and CometKiwi services: [`scripts/rl/servers`](scripts/rl/servers)
+- `verl` checkpoint export: [`scripts/rl/export_hf_checkpoint.sh`](scripts/rl/export_hf_checkpoint.sh)
+- SFT/RL weight interpolation: [`scripts/rl/linear_merge.py`](scripts/rl/linear_merge.py)
+
+See [`scripts/rl/README.md`](scripts/rl/README.md) for installation, input schema, reward-service deployment, APIs, and example commands.
 
 ## 📚 Reference
 

--- a/examples/rl.json
+++ b/examples/rl.json
@@ -1,0 +1,48 @@
+[
+  {
+    "data_source": "mt/sft_dataset_v11",
+    "prompt": [
+      {
+        "role": "user",
+        "content": "Translate this from English to Chinese (Simplified):\nEnglish: I was buying new tires.\nChinese (Simplified):"
+      }
+    ],
+    "ability": "translation",
+    "reward_model": {
+      "style": "rule",
+      "ground_truth": "我当时正在买新轮胎。"
+    },
+    "extra_info": {
+      "index": 130492,
+      "prompt": "Translate this from English to Chinese (Simplified):\nEnglish: I was buying new tires.\nChinese (Simplified):",
+      "reference": "我当时正在买新轮胎。",
+      "source": "I was buying new tires.",
+      "source_language": "English",
+      "target_language": "Chinese (Simplified)",
+      "split": "train"
+    }
+  },
+  {
+    "data_source": "mt/sft_dataset_v11",
+    "prompt": [
+      {
+        "role": "user",
+        "content": "Translate this from English to Chinese (Simplified):\nEnglish: It was a gesture that ended a crisis.\nChinese (Simplified):"
+      }
+    ],
+    "ability": "translation",
+    "reward_model": {
+      "style": "rule",
+      "ground_truth": "这一举动化解了一场危机。"
+    },
+    "extra_info": {
+      "index": 141238,
+      "prompt": "Translate this from English to Chinese (Simplified):\nEnglish: It was a gesture that ended a crisis.\nChinese (Simplified):",
+      "reference": "这一举动化解了一场危机。",
+      "source": "It was a gesture that ended a crisis.",
+      "source_language": "English",
+      "target_language": "Chinese (Simplified)",
+      "split": "val"
+    }
+  }
+]

--- a/scripts/rl/README.md
+++ b/scripts/rl/README.md
@@ -1,0 +1,231 @@
+# GRPO Fine-tuning and Model Merging
+
+This directory contains the code used for the MiLMMT-46 reinforcement-learning workflow:
+
+- `run_grpo.sh`: GRPO training with `verl` and vLLM.
+- `rewards/mt_dual_comet_reward.py`: dual-QE reward with an OpenLID language gate.
+- `servers/qe_server.py`: batched COMET QE service with an optional OpenLID-gated endpoint.
+- `servers/run_qe_server.sh`: launch one xCOMET or CometKiwi service process.
+- `servers/start_reward_servers.sh`: launch xCOMET/OpenLID and CometKiwi GPU pools.
+- `export_hf_checkpoint.sh`: convert a sharded `verl` FSDP actor checkpoint to Hugging Face format.
+- `linear_merge.py`: linearly interpolate the SFT and RL Hugging Face checkpoints.
+
+## Environment
+
+Python 3.10 or later is required. The released runs used `verl` commit
+`8ebf167e32e790e92a85eae2ddbecb8c515d8156`.
+
+```bash
+git clone https://github.com/volcengine/verl.git /path/to/verl
+git -C /path/to/verl checkout 8ebf167e32e790e92a85eae2ddbecb8c515d8156
+
+pip install -r requirements-rl.txt
+pip install -e "/path/to/verl[vllm]"
+```
+
+PyTorch and vLLM wheels are CUDA-dependent. Adjust their installation when the pinned versions in
+`requirements-rl.txt` do not match your CUDA and driver environment.
+
+## Input Data
+
+`run_grpo.sh` consumes existing `verl`-compatible Parquet files. It does not create, split, filter, or score data.
+`examples/rl.json` is a small, human-readable JSON example of the required row structure; it is not passed directly
+to `run_grpo.sh`. Convert your JSON records into separate `train.parquet` and `val.parquet` files before training.
+
+For example, using the `datasets` library:
+
+```bash
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+from datasets import Dataset
+
+rows = json.loads(Path("examples/rl.json").read_text())
+for split in ("train", "val"):
+    split_rows = [row for row in rows if row["extra_info"]["split"] == split]
+    if not split_rows:
+        raise ValueError(f"No rows found for split={split!r}")
+    Dataset.from_list(split_rows).to_parquet(f"{split}.parquet")
+PY
+```
+
+Then pass the generated files through `TRAIN_FILE` and `VAL_FILE`. Each row should contain the standard `verl` RL fields and, for the included reward, at least:
+
+```text
+prompt: list[{"role": "user", "content": "..."}]
+reward_model.ground_truth: reference translation
+extra_info.source: source sentence
+extra_info.target_language: expected target-language name
+```
+
+The target-language name must use the naming convention expected by the OpenLID service.
+
+## Reward Services
+
+The included server uses direct COMET `predict_step` inference and batches concurrent HTTP requests before each
+model forward pass. The same implementation serves either xCOMET or CometKiwi, depending on the checkpoint passed
+through `QE_MODEL_PATH`. Supplying `OPENLID_MODEL_PATH` additionally enables the OpenLID-gated route.
+
+Prepare local paths to the following model files before starting the services:
+
+- an xCOMET checkpoint directory or `.ckpt` file;
+- a CometKiwi checkpoint directory or `.ckpt` file;
+- an OpenLID-v3 fastText `.bin` model.
+
+Model files are not stored in this repository. If a COMET directory is passed, the server first looks for
+`checkpoints/model.ckpt` and then for another `.ckpt` below that directory.
+
+### Start Individual Services
+
+Start xCOMET with OpenLID on port 8008:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 \
+QE_MODEL_PATH=/path/to/xcomet \
+OPENLID_MODEL_PATH=/path/to/openlid-v3.bin \
+QE_PORT=8008 \
+bash scripts/rl/servers/run_qe_server.sh
+```
+
+Start CometKiwi on port 8012:
+
+```bash
+CUDA_VISIBLE_DEVICES=1 \
+QE_MODEL_PATH=/path/to/cometkiwi \
+QE_PORT=8012 \
+bash scripts/rl/servers/run_qe_server.sh
+```
+
+Set `QE_HOST` to the desired bind address. The main tuning variables are
+`QE_PREDICT_BATCH_SIZE`, `QE_MAX_SERVER_BATCH_SIZE`, `QE_MAX_WAIT_MS`, and `QE_DEVICE`. Set
+`QE_SET_HF_HUB_CACHE=0` for checkpoints whose encoder configuration contains a local absolute path that must not be
+resolved through the Hugging Face cache.
+
+### Start Both GPU Pools
+
+The convenience launcher starts one process per listed GPU and prints the exact URL lists to pass to training:
+
+```bash
+XCOMET_MODEL_PATH=/path/to/xcomet \
+COMETKIWI_MODEL_PATH=/path/to/cometkiwi \
+OPENLID_MODEL_PATH=/path/to/openlid-v3.bin \
+XCOMET_DEVICES=0,1,2,3 \
+COMETKIWI_DEVICES=4,5,6,7 \
+bash scripts/rl/servers/start_reward_servers.sh
+```
+
+xCOMET/OpenLID ports start at `XCOMET_BASE_PORT=8008`; CometKiwi ports start at
+`COMETKIWI_BASE_PORT=8012`. Override `REWARD_ADVERTISE_HOST` when the printed URLs should use a hostname or address
+other than `127.0.0.1`.
+
+### API Contract
+
+The training script accepts one or more comma-separated endpoint URLs:
+
+- `XCOMET_URLS`: full `/score_openlid` endpoints for xCOMET QE plus OpenLID gating.
+- `COMETKIWI_URLS`: full `/score` endpoints for CometKiwi QE.
+
+The xCOMET/OpenLID endpoint receives:
+
+```json
+{"items": [{"src": "source", "mt": "translation", "tgt_lang": "English"}]}
+```
+
+and returns at least the fields consumed by the reward client:
+
+```json
+{
+  "results": [{
+    "qe": 0.82,
+    "la_ok": 1,
+    "la_skip": 0,
+    "pred_iso": "eng_Latn",
+    "tgt_iso": "eng_Latn"
+  }]
+}
+```
+
+The CometKiwi endpoint receives `{"items": [{"src": "source", "mt": "translation"}]}` and returns at least
+`{"results": [{"score": 0.79}]}`.
+
+When `la_ok=1`, the reward is `(xCOMET + CometKiwi) / 2`. When `la_ok=0`, the reward is
+`DUALCOMET_LA_FAIL_SCORE`, which defaults to `0.0`. This preserves the released OpenLID hard-gating behavior.
+`XCOMET_RETRIES=-1` enables infinite retries; set a non-negative value to fail after a bounded number of retries.
+
+Check either service with `curl http://127.0.0.1:8008/health`. A pure QE request can be tested with:
+
+```bash
+curl -X POST http://127.0.0.1:8012/score \
+  -H 'Content-Type: application/json' \
+  -d '{"items":[{"src":"Hello","mt":"Bonjour"}]}'
+```
+
+## GRPO Training
+
+The launcher defaults reproduce the main 12B training hyperparameters: rollout `n=8`, prompt/response limits of
+4096 tokens, learning rate `1e-6`, KL coefficient `0.001`, batch and mini-batch sizes of 128, and three epochs.
+Hardware, paths, and run names remain configurable through environment variables.
+
+```bash
+VERL_ROOT=/path/to/verl \
+MODEL_PATH=xiaomi-research/MiLMMT-46-12B-v0.1 \
+TRAIN_FILE=/path/to/train.parquet \
+VAL_FILE=/path/to/val.parquet \
+XCOMET_URLS=http://reward-host-1:8008/score_openlid,http://reward-host-2:8008/score_openlid \
+COMETKIWI_URLS=http://reward-host-1:8012/score,http://reward-host-2:8012/score \
+NNODES=4 \
+NGPUS_PER_NODE=8 \
+bash scripts/rl/run_grpo.sh
+```
+
+The default logger is console-only. To enable Weights & Biases, export credentials in the environment rather than
+putting them in the script or command-line overrides:
+
+```bash
+export WANDB_API_KEY=...
+export WANDB_ENTITY=...
+export LOGGER='["console","wandb"]'
+```
+
+Then run the same training command above. Do not put API keys directly in scripts or Hydra command-line overrides.
+
+For distributed runs, follow the standard `verl` launch procedure for your environment before starting training.
+
+## Export a Hugging Face Checkpoint
+
+The exporter reads `latest_checkpointed_iteration.txt` when `STEP` is omitted and expects the actor shards under
+`global_step_<STEP>/actor`.
+
+```bash
+VERL_ROOT=/path/to/verl \
+BASE_MODEL_DIR=/path/to/MiLMMT-46-12B-v0.1 \
+bash scripts/rl/export_hf_checkpoint.sh /path/to/experiment
+```
+
+The default output is `/path/to/experiment/merged_hf_step<STEP>`. Set `TARGET_DIR` to choose another directory.
+`BASE_MODEL_DIR` is only used to restore missing processor configuration files for multimodal Gemma 3 checkpoints.
+The exporter refuses to overwrite an existing output directory.
+
+## Merge SFT and RL Weights
+
+Both inputs must already be Hugging Face safetensors checkpoints with the same architecture. `model_a` is the SFT
+checkpoint and receives weight `alpha`; `model_b` is the exported RL checkpoint and receives weight `1 - alpha`:
+
+```text
+theta_merged = alpha * theta_SFT + (1 - alpha) * theta_RL
+```
+
+For an equal interpolation:
+
+```bash
+python3 scripts/rl/linear_merge.py \
+  --model_a /path/to/MiLMMT-46-12B-v0.1 \
+  --model_b /path/to/experiment/merged_hf_step714 \
+  --alpha 0.5 \
+  --out /path/to/MiLMMT-46-12B-v1.0
+```
+
+The output follows the RL checkpoint's shard layout and metadata and includes `merge_manifest.json`. The script
+rejects `alpha` values outside `[0, 1]` and refuses to overwrite an existing output directory unless
+`--overwrite` is supplied.

--- a/scripts/rl/export_hf_checkpoint.sh
+++ b/scripts/rl/export_hf_checkpoint.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: export_hf_checkpoint.sh EXPERIMENT_DIR [STEP] [DTYPE] [BASE_MODEL_DIR]
+
+Environment:
+  VERL_ROOT       path to the verl checkout
+  TARGET_DIR      optional output directory (default: EXPERIMENT_DIR/merged_hf_stepSTEP)
+  DTYPE           optional dtype when the third positional argument is omitted
+  BASE_MODEL_DIR  optional base model directory used to restore processor files
+
+The experiment directory must contain global_step_<STEP>/actor. If STEP is
+omitted, latest_checkpointed_iteration.txt is used.
+EOF
+    exit 2
+}
+
+[[ $# -ge 1 ]] || usage
+: "${VERL_ROOT:?Set VERL_ROOT to the verl checkout}"
+[[ -d "${VERL_ROOT}" ]] || { echo "verl directory not found: ${VERL_ROOT}" >&2; exit 2; }
+
+EXP_DIR=$(realpath "$1")
+STEP=${2:-}
+DTYPE=${3:-${DTYPE:-bfloat16}}
+BASE_MODEL_DIR=${4:-${BASE_MODEL_DIR:-}}
+
+[[ -d "${EXP_DIR}" ]] || { echo "Experiment directory not found: ${EXP_DIR}" >&2; exit 2; }
+
+if [[ -z "${STEP}" ]]; then
+    LATEST_FILE="${EXP_DIR}/latest_checkpointed_iteration.txt"
+    [[ -f "${LATEST_FILE}" ]] || {
+        echo "Missing step and latest_checkpointed_iteration.txt: ${LATEST_FILE}" >&2
+        exit 2
+    }
+    STEP=$(tr -d '[:space:]' < "${LATEST_FILE}")
+fi
+
+[[ "${STEP}" =~ ^[0-9]+$ ]] || { echo "STEP must be a non-negative integer: ${STEP}" >&2; exit 2; }
+if [[ -n "${BASE_MODEL_DIR}" && ! -d "${BASE_MODEL_DIR}" ]]; then
+    echo "Base model directory not found: ${BASE_MODEL_DIR}" >&2
+    exit 2
+fi
+
+LOCAL_DIR="${EXP_DIR}/global_step_${STEP}/actor"
+TARGET_DIR=${TARGET_DIR:-${EXP_DIR}/merged_hf_step${STEP}}
+
+[[ -d "${LOCAL_DIR}" ]] || { echo "Actor checkpoint not found: ${LOCAL_DIR}" >&2; exit 2; }
+if [[ -e "${TARGET_DIR}" ]]; then
+    echo "Target already exists: ${TARGET_DIR}" >&2
+    echo "Set TARGET_DIR to a new path rather than overwriting it." >&2
+    exit 2
+fi
+
+export PYTHONPATH="${VERL_ROOT}:${PYTHONPATH:-}"
+python3 -m verl.model_merger merge \
+    --backend fsdp \
+    --local_dir "${LOCAL_DIR}" \
+    --target_dir "${TARGET_DIR}" \
+    --trust-remote-code
+
+[[ -f "${TARGET_DIR}/config.json" ]] || {
+    echo "Export completed without config.json: ${TARGET_DIR}" >&2
+    exit 2
+}
+
+python3 - "${TARGET_DIR}/config.json" "${DTYPE}" <<'PY'
+import json
+import sys
+
+config_path, dtype = sys.argv[1:]
+with open(config_path, encoding="utf-8") as handle:
+    config = json.load(handle)
+
+
+def update_dtype(node):
+    if not isinstance(node, dict):
+        return
+    if "dtype" in node or "torch_dtype" in node:
+        node["dtype"] = dtype
+        node["torch_dtype"] = dtype
+    for value in node.values():
+        if isinstance(value, dict):
+            update_dtype(value)
+
+
+update_dtype(config)
+with open(config_path, "w", encoding="utf-8") as handle:
+    json.dump(config, handle, ensure_ascii=False, indent=2)
+    handle.write("\n")
+PY
+
+IS_MULTIMODAL=$(python3 - "${TARGET_DIR}/config.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    print("1" if "vision_config" in json.load(handle) else "0")
+PY
+)
+
+if [[ "${IS_MULTIMODAL}" == "1" ]]; then
+    missing=()
+    for filename in preprocessor_config.json processor_config.json; do
+        [[ -f "${TARGET_DIR}/${filename}" ]] || missing+=("${filename}")
+    done
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        [[ -n "${BASE_MODEL_DIR}" ]] || {
+            echo "The merged model is multimodal and needs BASE_MODEL_DIR to restore: ${missing[*]}" >&2
+            exit 2
+        }
+        for filename in "${missing[@]}"; do
+            [[ -f "${BASE_MODEL_DIR}/${filename}" ]] || {
+                echo "Missing ${filename} in BASE_MODEL_DIR: ${BASE_MODEL_DIR}" >&2
+                exit 2
+            }
+            cp "${BASE_MODEL_DIR}/${filename}" "${TARGET_DIR}/"
+        done
+    fi
+fi
+
+echo "Exported Hugging Face checkpoint: ${TARGET_DIR}"

--- a/scripts/rl/linear_merge.py
+++ b/scripts/rl/linear_merge.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Linearly interpolate SFT and RL Hugging Face checkpoints.
+
+The merge is defined as::
+
+    theta_merged = alpha * theta_sft + (1 - alpha) * theta_rl
+
+Both inputs must use the same architecture and safetensors parameter names.
+Tensors are processed shard by shard, and the output shard layout and metadata
+follow the RL checkpoint. Gemma 3 tied embeddings are written without a
+separate ``lm_head.weight`` tensor.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import math
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+
+INDEX_FILENAME = "model.safetensors.index.json"
+SINGLE_SHARD_FILENAME = "model.safetensors"
+MANIFEST_FILENAME = "merge_manifest.json"
+
+
+def find_embedding_keys(keys: list[str]) -> tuple[str | None, str | None]:
+    """Find the architecture-specific lm_head and embedding tensor names."""
+    lm_head = next((key for key in keys if key.endswith("lm_head.weight")), None)
+    embed = next((key for key in keys if key.endswith("model.embed_tokens.weight")), None)
+    return lm_head, embed
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError(f"Expected a JSON object in {path}")
+    return value
+
+
+def build_reader(
+    model_dir: str,
+) -> tuple[Callable[[str], torch.Tensor | None], list[str]]:
+    """Return a lazy tensor reader and the checkpoint's parameter names."""
+    root = Path(model_dir)
+    if not root.is_dir():
+        raise FileNotFoundError(f"Model directory not found: {root}")
+
+    index_path = root / INDEX_FILENAME
+    single_shard_path = root / SINGLE_SHARD_FILENAME
+    if index_path.is_file():
+        index = load_json(index_path)
+        weight_map = index.get("weight_map")
+        if not isinstance(weight_map, dict) or not weight_map:
+            raise ValueError(f"Missing weight_map in {index_path}")
+    elif single_shard_path.is_file():
+        with safe_open(single_shard_path, framework="pt") as handle:
+            weight_map = {key: SINGLE_SHARD_FILENAME for key in handle.keys()}
+    else:
+        raise FileNotFoundError(
+            f"No {INDEX_FILENAME} or {SINGLE_SHARD_FILENAME} found in {root}"
+        )
+
+    if not all(isinstance(key, str) and isinstance(shard, str) for key, shard in weight_map.items()):
+        raise ValueError(f"Invalid weight_map entries in {root}")
+
+    for shard in set(weight_map.values()):
+        if not (root / shard).is_file():
+            raise FileNotFoundError(f"Checkpoint shard not found: {root / shard}")
+
+    handles: dict[str, Any] = {}
+
+    def read(key: str) -> torch.Tensor | None:
+        shard = weight_map.get(key)
+        if shard is None:
+            return None
+        if shard not in handles:
+            handles[shard] = safe_open(root / shard, framework="pt")
+        return handles[shard].get_tensor(key)
+
+    return read, list(weight_map)
+
+
+def validate_alpha(alpha: float) -> None:
+    if not math.isfinite(alpha) or not 0.0 <= alpha <= 1.0:
+        raise ValueError(f"alpha must be finite and within [0, 1], got {alpha}")
+
+
+def prepare_output_dir(out_dir: Path, overwrite: bool) -> None:
+    if out_dir.exists():
+        if not out_dir.is_dir():
+            raise NotADirectoryError(f"Output path is not a directory: {out_dir}")
+        if not overwrite:
+            raise FileExistsError(
+                f"Output directory already exists: {out_dir}. Use --overwrite to replace generated files."
+            )
+        for path in out_dir.iterdir():
+            if path.name in {INDEX_FILENAME, MANIFEST_FILENAME} or path.suffix == ".safetensors":
+                path.unlink()
+    else:
+        out_dir.mkdir(parents=True)
+
+
+def merge(
+    model_a: str,
+    model_b: str,
+    alpha: float,
+    out_dir: str,
+    overwrite: bool = False,
+) -> None:
+    """Merge model A (SFT) and model B (RL) into ``out_dir``."""
+    validate_alpha(alpha)
+    sft_weight, rl_weight = alpha, 1.0 - alpha
+    read_sft, sft_keys = build_reader(model_a)
+    read_rl, rl_keys = build_reader(model_b)
+
+    _, sft_embed = find_embedding_keys(sft_keys)
+    rl_lm_head, rl_embed = find_embedding_keys(rl_keys)
+    if sft_embed is None or rl_embed is None:
+        raise KeyError("Could not find model.embed_tokens.weight in both models")
+
+    rl_root = Path(model_b)
+    index_path = rl_root / INDEX_FILENAME
+    if index_path.is_file():
+        rl_index = load_json(index_path)
+        weight_map = rl_index["weight_map"]
+        has_index = True
+    else:
+        rl_index = {"metadata": {}}
+        weight_map = {key: SINGLE_SHARD_FILENAME for key in rl_keys}
+        has_index = False
+
+    output_keys = [key for key in rl_keys if key != rl_lm_head]
+    sft_key_for_rl_key: dict[str, str] = {}
+    for key in output_keys:
+        if key in sft_keys:
+            sft_key_for_rl_key[key] = key
+        elif key == rl_embed:
+            sft_key_for_rl_key[key] = sft_embed
+        else:
+            raise KeyError(f"RL tensor {key!r} is missing from the SFT checkpoint")
+
+    shard_to_keys: dict[str, list[str]] = {}
+    for key in output_keys:
+        shard_to_keys.setdefault(weight_map[key], []).append(key)
+
+    output_root = Path(out_dir)
+    prepare_output_dir(output_root, overwrite)
+
+    total_size = 0
+    for shard, keys in shard_to_keys.items():
+        merged_tensors: dict[str, torch.Tensor] = {}
+        for key in keys:
+            sft_tensor = read_sft(sft_key_for_rl_key[key])
+            rl_tensor = read_rl(key)
+            if sft_tensor is None or rl_tensor is None:
+                raise KeyError(f"Failed to load tensor {key!r} from both checkpoints")
+            if sft_tensor.shape != rl_tensor.shape:
+                raise ValueError(
+                    f"Tensor shape mismatch for {key}: SFT={tuple(sft_tensor.shape)}, "
+                    f"RL={tuple(rl_tensor.shape)}"
+                )
+
+            merged = sft_weight * sft_tensor.float() + rl_weight * rl_tensor.float()
+            merged_tensors[key] = merged.to(sft_tensor.dtype).contiguous()
+            total_size += merged_tensors[key].numel() * merged_tensors[key].element_size()
+
+        shard_path = output_root / shard
+        shard_path.parent.mkdir(parents=True, exist_ok=True)
+        save_file(merged_tensors, shard_path, metadata={"format": "pt"})
+        print(f"wrote {shard} ({len(keys)} tensors)")
+        del merged_tensors
+        gc.collect()
+
+    if has_index:
+        metadata = dict(rl_index.get("metadata", {}))
+        metadata["total_size"] = total_size
+        merged_index = {
+            "metadata": metadata,
+            "weight_map": {key: weight_map[key] for key in output_keys},
+        }
+        with (output_root / INDEX_FILENAME).open("w", encoding="utf-8") as handle:
+            json.dump(merged_index, handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+
+    for source in rl_root.iterdir():
+        if source.suffix == ".safetensors" or source.name in {INDEX_FILENAME, MANIFEST_FILENAME}:
+            continue
+        if source.is_file():
+            shutil.copy2(source, output_root / source.name)
+
+    config_path = output_root / "config.json"
+    if config_path.is_file():
+        config = load_json(config_path)
+        config["tie_word_embeddings"] = True
+        with config_path.open("w", encoding="utf-8") as handle:
+            json.dump(config, handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+
+    manifest = {
+        "merge_method": "linear_interpolation",
+        "formula": "alpha * SFT + (1 - alpha) * RL",
+        "alpha": alpha,
+        "model_a": {"role": "SFT", "name": Path(model_a).name, "weight": sft_weight},
+        "model_b": {"role": "RL", "name": Path(model_b).name, "weight": rl_weight},
+        "output_layout": "model_b",
+        "tie_word_embeddings": True,
+    }
+    with (output_root / MANIFEST_FILENAME).open("w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+
+    print(f"done: {output_root}")
+
+
+def alpha_arg(value: str) -> float:
+    alpha = float(value)
+    try:
+        validate_alpha(alpha)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+    return alpha
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Merge SFT and RL safetensors checkpoints by linear interpolation."
+    )
+    parser.add_argument("--model_a", required=True, help="SFT Hugging Face model directory (weight alpha)")
+    parser.add_argument("--model_b", required=True, help="RL Hugging Face model directory (weight 1-alpha)")
+    parser.add_argument("--alpha", required=True, type=alpha_arg, help="SFT weight in [0, 1]")
+    parser.add_argument("--out", required=True, help="output Hugging Face model directory")
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="replace generated weight, index, and manifest files in an existing output directory",
+    )
+    args = parser.parse_args()
+
+    print(f"merge: {args.alpha} * SFT + {1.0 - args.alpha} * RL -> {args.out}")
+    merge(args.model_a, args.model_b, args.alpha, args.out, overwrite=args.overwrite)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rl/requirements-rl.txt
+++ b/scripts/rl/requirements-rl.txt
@@ -1,0 +1,13 @@
+# Tested RL environment. Install verl separately at commit
+# 8ebf167e32e790e92a85eae2ddbecb8c515d8156 as documented in scripts/rl/README.md.
+torch==2.8.0
+vllm==0.11.0
+transformers==4.57.1
+requests==2.32.5
+safetensors==0.6.2
+unbabel-comet==2.2.7
+fasttext==0.9.3
+fastapi==0.118.0
+uvicorn[standard]==0.37.0
+pydantic==2.11.9
+regex==2025.9.18

--- a/scripts/rl/rewards/mt_dual_comet_reward.py
+++ b/scripts/rl/rewards/mt_dual_comet_reward.py
@@ -1,0 +1,174 @@
+"""Dual-QE sequence reward with an OpenLID language gate.
+
+The xCOMET/OpenLID endpoint returns a reference-free xCOMET QE score and a
+language-match decision. The CometKiwi endpoint returns a second
+reference-free QE score. Language-correct outputs receive the mean of the two
+QE scores; language-mismatched outputs receive ``la_fail_score``.
+
+Both services are external HTTP dependencies. The client does not load reward
+models locally.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Reuse the HTTP client helpers from the adjacent xCOMET reward module.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from mt_xcomet_reward import (  # noqa: E402
+    _extract_source,
+    _float_arg,
+    _int_arg,
+    _normalize,
+    _xcomet_post,
+)
+
+DEFAULT_XCOMET_URL = "http://127.0.0.1:8008/score_openlid"
+DEFAULT_COMETKIWI_URL = "http://127.0.0.1:8012/score"
+
+
+def _parse_urls_named(urls: Any, url: Any, env_urls: str, env_url: str, default: str) -> list[str]:
+    """Resolve comma-separated service URLs from arguments or environment."""
+    raw = urls or os.getenv(env_urls) or url or os.getenv(env_url) or default
+    if isinstance(raw, (list, tuple)):
+        parsed = [str(x).strip() for x in raw if str(x).strip()]
+    else:
+        parsed = [x.strip() for x in str(raw).split(",") if x.strip()]
+    if not parsed:
+        raise ValueError(f"At least one URL is required (env {env_urls}/{env_url}).")
+    return parsed
+
+
+def _score_batch(
+    solution_strs: list[str],
+    ground_truths: list[str],
+    extra_infos: list[dict[str, Any]],
+    *,
+    xcomet_urls: list[str],
+    cometkiwi_urls: list[str],
+    timeout_s: float,
+    retries: int,
+    la_fail_score: float,
+) -> list[dict[str, Any]]:
+    """Score a batch while preserving input order."""
+    openlid_items: list[dict[str, str]] = []
+    cometkiwi_items: list[dict[str, str]] = []
+    for solution, _ground_truth, extra_info in zip(
+        solution_strs,
+        ground_truths,
+        extra_infos,
+        strict=True,
+    ):
+        extra_info = extra_info or {}
+        src = _extract_source(extra_info)
+        mt = _normalize(solution)
+        tgt_lang = str(extra_info.get("target_language") or "")
+        openlid_items.append({"src": src, "mt": mt, "tgt_lang": tgt_lang})
+        cometkiwi_items.append({"src": src, "mt": mt})
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        fut_x = pool.submit(_xcomet_post, openlid_items, xcomet_urls, timeout_s, retries)
+        fut_k = pool.submit(_xcomet_post, cometkiwi_items, cometkiwi_urls, timeout_s, retries)
+        openlid_results = fut_x.result()
+        cometkiwi_results = fut_k.result()
+
+    n = len(solution_strs)
+    if not (len(openlid_results) == len(cometkiwi_results) == n):
+        raise RuntimeError(
+            f"dualcomet result length mismatch: xcomet_openlid={len(openlid_results)} "
+            f"cometkiwi={len(cometkiwi_results)} expected={n}"
+        )
+
+    scores: list[dict[str, Any]] = []
+    for xres, kres in zip(openlid_results, cometkiwi_results, strict=True):
+        xcomet = float(xres.get("qe", 0.0))
+        cometkiwi = float(kres.get("score", 0.0))
+        la_ok = int(xres.get("la_ok", 0))
+        if la_ok == 0:
+            score = float(la_fail_score)
+        else:
+            score = (xcomet + cometkiwi) / 2.0
+        scores.append(
+            {
+                "score": float(score),
+                "xcomet": xcomet,
+                "cometkiwi": cometkiwi,
+                "la_ok": float(la_ok),
+                "la_skip": float(xres.get("la_skip", 0)),
+                "pred_iso": xres.get("pred_iso", ""),
+                "tgt_iso": xres.get("tgt_iso", ""),
+            }
+        )
+    return scores
+
+
+def compute_score(
+    data_source: str | None = None,
+    solution_str: str | None = None,
+    ground_truth: str | None = None,
+    extra_info: dict[str, Any] | None = None,
+    data_sources: list[str] | None = None,
+    solution_strs: list[str] | None = None,
+    ground_truths: list[str] | None = None,
+    extra_infos: list[dict[str, Any]] | None = None,
+    xcomet_url: str | None = None,
+    xcomet_urls: str | list[str] | None = None,
+    cometkiwi_url: str | None = None,
+    cometkiwi_urls: str | list[str] | None = None,
+    timeout_s: float | None = None,
+    retries: int | None = None,
+    la_fail_score: float | None = None,
+    **_: Any,
+) -> dict[str, Any] | list[dict[str, Any]]:
+    """verl custom reward entry point for batch or single-example calls.
+
+    Explicit function arguments take precedence over environment variables and
+    built-in defaults. ``DUALCOMET_TIMEOUT_S`` and ``DUALCOMET_RETRIES`` can
+    override their corresponding ``XCOMET_*`` values.
+    """
+    resolved_xcomet = _parse_urls_named(
+        xcomet_urls,
+        xcomet_url,
+        "XCOMET_URLS",
+        "XCOMET_URL",
+        DEFAULT_XCOMET_URL,
+    )
+    resolved_cometkiwi = _parse_urls_named(
+        cometkiwi_urls,
+        cometkiwi_url,
+        "COMETKIWI_URLS",
+        "COMETKIWI_URL",
+        DEFAULT_COMETKIWI_URL,
+    )
+    resolved_timeout_s = _float_arg(timeout_s, "DUALCOMET_TIMEOUT_S", _float_arg(None, "XCOMET_TIMEOUT_S", 120.0))
+    resolved_retries = _int_arg(retries, "DUALCOMET_RETRIES", _int_arg(None, "XCOMET_RETRIES", 7))
+    resolved_la_fail = _float_arg(la_fail_score, "DUALCOMET_LA_FAIL_SCORE", 0.0)
+
+    if solution_strs is not None:
+        refs = ground_truths or [""] * len(solution_strs)
+        extras = extra_infos or [{} for _ in solution_strs]
+        return _score_batch(
+            [str(x or "") for x in solution_strs],
+            [str(x or "") for x in refs],
+            [dict(x or {}) for x in extras],
+            xcomet_urls=resolved_xcomet,
+            cometkiwi_urls=resolved_cometkiwi,
+            timeout_s=resolved_timeout_s,
+            retries=resolved_retries,
+            la_fail_score=resolved_la_fail,
+        )
+
+    return _score_batch(
+        [solution_str or ""],
+        [ground_truth or ""],
+        [extra_info or {}],
+        xcomet_urls=resolved_xcomet,
+        cometkiwi_urls=resolved_cometkiwi,
+        timeout_s=resolved_timeout_s,
+        retries=resolved_retries,
+        la_fail_score=resolved_la_fail,
+    )[0]

--- a/scripts/rl/rewards/mt_xcomet_reward.py
+++ b/scripts/rl/rewards/mt_xcomet_reward.py
@@ -1,0 +1,384 @@
+"""Sequence-level machine translation reward based on xCOMET for verl GRPO training.
+
+The custom reward entry point is ``compute_score``. This module normalizes text,
+calls the scoring service, applies the configured score transform, and clips the
+result to the requested range.
+
+The xCOMET model is kept in a persistent HTTP service so reward workers can
+reuse one loaded model instead of loading a copy in every worker.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from itertools import count
+from typing import Any
+
+import requests
+
+
+# Module logger for request failures, retries, and diagnostics.
+LOGGER = logging.getLogger("mt_xcomet_reward")
+
+# Set XCOMET_DEBUG_CONN=1 to enable urllib3 connection-pool diagnostics.
+if os.getenv("XCOMET_DEBUG_CONN", "").strip().lower() in ("1", "true", "yes", "on"):
+    logging.getLogger("urllib3.connectionpool").setLevel(logging.DEBUG)
+    # Add a stderr handler when the root logger has no configured handlers.
+    if not logging.getLogger().handlers:
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format="%(asctime)s.%(msecs)03d %(levelname)s %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    LOGGER.warning("XCOMET_DEBUG_CONN is enabled; urllib3 connection-pool diagnostics are active.")
+
+# EOS markers that may remain in generated output.
+EOS_MARKERS = ("<eos>", "</s>")
+
+# Default xCOMET endpoint used when no URL is configured explicitly.
+DEFAULT_XCOMET_URL = "http://127.0.0.1:8008/score"
+
+# Round-robin counter for selecting among multiple xCOMET endpoints.
+# Starting from the process ID spreads the initial selection across workers.
+_URL_COUNTER = count(os.getpid())
+
+# Keep one requests.Session per reward worker thread.
+_THREAD_LOCAL = threading.local()
+
+
+def _strip_eos(text: str) -> str:
+    """Truncate at the first EOS marker while preserving surrounding whitespace."""
+    text = text or ""
+    # Do not strip leading or trailing whitespace.
+    for marker in EOS_MARKERS:
+        if marker in text:
+            text = text.split(marker, 1)[0]
+    return text
+
+
+def _normalize(text: str) -> str:
+    """Normalize text for xCOMET while removing only EOS markers."""
+    text = _strip_eos(text)
+    # text = text.replace("\u3000", " ")   # fullwidth space (U+3000) -> half-width space
+    # text = re.sub(r"\s+", " ", text)     # collapse consecutive whitespace into one space
+    # return text.strip()                  # strip leading/trailing whitespace
+    return text
+
+
+def _extract_source(extra_info: dict[str, Any]) -> str:
+    """Extract the source sentence from ``extra_info`` for xCOMET scoring.
+
+    Lookup order:
+      1. ``source``, ``src``, or ``source_text`` in ``extra_info``.
+      2. A source-language-prefixed line in the prompt.
+      3. Raise an error when no source can be found.
+    """
+    for key in ("source", "src", "source_text"):
+        value = extra_info.get(key)
+        if value:
+            return str(value)
+
+    prompt = str(extra_info.get("prompt") or "")
+    source_language = str(extra_info.get("source_language") or "")
+    if source_language:
+        prefix = f"{source_language}:"
+        for line in prompt.splitlines():
+            if line.startswith(prefix):
+                return line[len(prefix) :].strip()
+
+    raise KeyError("xCOMET reward requires extra_info['source'] or extra_info['src'].")
+
+
+def _float_arg(value: Any, env_name: str, default: float) -> float:
+    """Resolve a floating-point option from an argument, environment, or default."""
+    if value is not None:
+        return float(value)
+    return float(os.getenv(env_name, default))
+
+
+def _int_arg(value: Any, env_name: str, default: int) -> int:
+    """Resolve an integer option from an argument, environment, or default."""
+    if value is not None:
+        return int(value)
+    return int(os.getenv(env_name, default))
+
+
+def _bool_arg(value: Any, env_name: str, default: bool) -> bool:
+    """Resolve a boolean option from an argument, environment, or default.
+
+    The values 1/true/yes/on are treated as true, case-insensitively.
+    Other values are treated as false.
+    """
+    if value is not None:
+        if isinstance(value, str):
+            return value.strip().lower() in ("1", "true", "yes", "on")
+        return bool(value)
+    raw = os.getenv(env_name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _parse_urls(xcomet_urls: Any = None, xcomet_url: Any = None) -> list[str]:
+    """Resolve a list of xCOMET endpoints, optionally supplied as CSV text.
+
+    Precedence is ``xcomet_urls`` argument, ``XCOMET_URLS`` environment
+    variable, ``xcomet_url`` argument, ``XCOMET_URL`` environment variable,
+    then the built-in default.
+    """
+    raw_value = xcomet_urls or os.getenv("XCOMET_URLS") or xcomet_url or os.getenv("XCOMET_URL") or DEFAULT_XCOMET_URL
+    if isinstance(raw_value, (list, tuple)):
+        urls = [str(item).strip() for item in raw_value if str(item).strip()]
+    else:
+        urls = [item.strip() for item in str(raw_value).split(",") if item.strip()]
+    if not urls:
+        raise ValueError("At least one xCOMET URL is required.")
+    return urls
+
+
+def _select_url(xcomet_urls: list[str], skip: set[str] | None = None) -> str:
+    """Select an endpoint in round-robin order, skipping failed endpoints when possible."""
+    candidates = [url for url in xcomet_urls if not skip or url not in skip]
+    if not candidates:
+        candidates = xcomet_urls
+    return candidates[next(_URL_COUNTER) % len(candidates)]
+
+
+def _get_session() -> requests.Session:
+    """Get a lazily initialized, thread-local requests.Session.
+
+    Set ``XCOMET_NO_KEEPALIVE=1`` to send ``Connection: close`` and avoid
+    stale keep-alive connections.
+    """
+    session = getattr(_THREAD_LOCAL, "session", None)
+    if session is None:
+        session = requests.Session()
+        # Ignore proxy settings inherited from the environment.
+        session.trust_env = False
+        if os.getenv("XCOMET_NO_KEEPALIVE", "").strip().lower() in ("1", "true", "yes", "on"):
+            # Disable connection reuse for this session.
+            session.headers["Connection"] = "close"
+        _THREAD_LOCAL.session = session
+    return session
+
+
+def _xcomet_post(items: list[dict[str, str]], xcomet_urls: list[str], timeout_s: float, retries: int) -> list[dict[str, Any]]:
+    """Submit a batch to xCOMET with retries and endpoint failover.
+
+    Each item contains ``src`` and ``mt``, and may contain ``ref``. An empty
+    batch returns immediately. The response must contain one result per item.
+
+    ``retries >= 0`` allows ``retries + 1`` attempts. ``retries < 0`` enables
+    infinite retrying until an endpoint succeeds.
+    """
+    if not items:
+        return []
+
+    payload = {"items": items}
+    last_error: Exception | None = None
+    session = _get_session()
+    infinite = retries < 0
+    max_attempts = None if infinite else retries + 1
+    failed_urls: set[str] = set()
+    attempt = 0
+    while infinite or attempt < max_attempts:
+        # In infinite mode, retry all endpoints after completing a failed round.
+        if infinite and failed_urls and len(failed_urls) >= len(xcomet_urls):
+            failed_urls = set()
+        xcomet_url = _select_url(xcomet_urls, skip=failed_urls)
+        try:
+            response = session.post(xcomet_url, json=payload, timeout=timeout_s)
+            response.raise_for_status()
+            data = response.json()
+            results = data.get("results")
+            if not isinstance(results, list) or len(results) != len(items):
+                raise RuntimeError(f"xCOMET service returned malformed results: {data}")
+            return results
+        except Exception as exc:
+            # Mark the endpoint as failed and retry after a bounded backoff.
+            last_error = exc
+            failed_urls.add(xcomet_url)
+            attempt_str = f"{attempt + 1}" if infinite else f"{attempt + 1}/{max_attempts}"
+            LOGGER.warning(
+                "xCOMET request to %s failed (attempt %s, %d item(s)): %r",
+                xcomet_url,
+                attempt_str,
+                len(items),
+                exc,
+            )
+            # Cap the backoff at two seconds and keep the exponent bounded.
+            if infinite or attempt < max_attempts - 1:
+                time.sleep(min(2.0, 0.25 * (2 ** min(attempt, 8))))
+            attempt += 1
+
+    # Only finite retry mode reaches this point.
+    LOGGER.error(
+        "xCOMET request failed after %d attempt(s) for %d item(s); tried URL(s): %s",
+        max_attempts,
+        len(items),
+        ", ".join(sorted(failed_urls)) or "<none>",
+        exc_info=last_error,
+    )
+    raise RuntimeError(
+        f"xCOMET request failed after {max_attempts} attempt(s). "
+        f"Start the service first, e.g. `bash scripts/rl/servers/run_qe_server.sh`, "
+        f"or set XCOMET_URLS for multiple servers. "
+        f"Last error: {last_error}"
+    )
+
+
+def _empty_score(empty_score: float) -> dict[str, float]:
+    """Build the fallback result for an empty or unscored translation."""
+    return {
+        "score": float(empty_score),
+        "xcomet": 0.0,
+        "xcomet_scaled": 0.0,
+        "empty": 1.0,
+        "xcomet_error_count": 0.0,
+    }
+
+
+def _score_batch(
+    solution_strs: list[str],
+    ground_truths: list[str],
+    extra_infos: list[dict[str, Any]],
+    *,
+    xcomet_urls: list[str],
+    timeout_s: float,
+    retries: int,
+    score_scale: float,
+    score_shift: float,
+    score_min: float,
+    score_max: float,
+    empty_score: float,
+    use_reference: bool,
+) -> list[dict[str, float]]:
+    """Score a batch of translations and return one metrics dictionary per input.
+
+    The process has three stages: normalize text, submit one batch to xCOMET,
+    then apply the score transform and restore the original order. The reward
+    is pure xCOMET scoring with no additional rule penalties.
+
+    ``use_reference=True`` includes ``ref`` for reference-based scoring;
+    ``False`` omits it and uses the reference-free QE path.
+    """
+    # Reserve output slots so results can be restored to input order.
+    scores: list[dict[str, float] | None] = [None] * len(solution_strs)
+    request_items: list[dict[str, str]] = []
+    request_meta: list[dict[str, float]] = []
+    request_indices: list[int] = []
+
+    # Stage one: normalize each item without changing its scoring semantics.
+    for idx, (solution, ground_truth, extra_info) in enumerate(zip(solution_strs, ground_truths, extra_infos, strict=True)):
+        extra_info = extra_info or {}
+        reference = _normalize(ground_truth)
+        hypothesis = _normalize(solution)
+        item = {"src": _extract_source(extra_info), "mt": hypothesis}
+        if use_reference:
+            item["ref"] = reference
+        request_items.append(item)
+        request_meta.append({"empty": 1.0 if not hypothesis else 0.0})
+        request_indices.append(idx)
+
+    # Stage two: submit the batch to xCOMET.
+    xcomet_results = _xcomet_post(request_items, xcomet_urls=xcomet_urls, timeout_s=timeout_s, retries=retries)
+
+    # Stage three: transform scores and restore the original order.
+    for idx, result, meta in zip(request_indices, xcomet_results, request_meta, strict=True):
+        raw_xcomet = float(result.get("score", 0.0))
+        xcomet_scaled = raw_xcomet * score_scale + score_shift
+        score = min(score_max, max(score_min, xcomet_scaled))
+        error_spans = result.get("error_spans") or []
+        scores[idx] = {
+            "score": float(score),
+            "xcomet": raw_xcomet,
+            "xcomet_scaled": float(xcomet_scaled),
+            "empty": meta["empty"],
+            "xcomet_error_count": float(len(error_spans) if isinstance(error_spans, list) else 0),
+        }
+
+    # Guard against an unexpected missing result.
+    return [score if score is not None else _empty_score(empty_score) for score in scores]
+
+
+def compute_score(
+    data_source: str | None = None,
+    solution_str: str | None = None,
+    ground_truth: str | None = None,
+    extra_info: dict[str, Any] | None = None,
+    data_sources: list[str] | None = None,
+    solution_strs: list[str] | None = None,
+    ground_truths: list[str] | None = None,
+    extra_infos: list[dict[str, Any]] | None = None,
+    xcomet_url: str | None = None,
+    xcomet_urls: str | list[str] | None = None,
+    timeout_s: float | None = None,
+    retries: int | None = None,
+    score_scale: float | None = None,
+    score_shift: float | None = None,
+    score_min: float | None = None,
+    score_max: float | None = None,
+    empty_score: float | None = None,
+    use_reference: bool | str | None = None,
+    **_: Any,
+) -> dict[str, float] | list[dict[str, float]]:
+    """verl custom reward entry point backed by an xCOMET HTTP service.
+
+    The final reward is the transformed and clipped xCOMET score without
+    language, repetition, or length penalties.
+
+    Both batch calls (``solution_strs`` and related lists) and single-item calls
+    (``solution_str`` and related fields) are supported. Scoring options can be
+    passed explicitly, read from their ``XCOMET_*`` environment variables, or
+    taken from the defaults below. Extra keyword arguments are ignored for
+    compatibility with future verl versions.
+    """
+
+    # Resolve configuration from arguments, environment variables, and defaults.
+    resolved_urls = _parse_urls(xcomet_urls=xcomet_urls, xcomet_url=xcomet_url)
+    resolved_timeout_s = _float_arg(timeout_s, "XCOMET_TIMEOUT_S", 600.0)
+    resolved_retries = _int_arg(retries, "XCOMET_RETRIES", 1)
+    resolved_score_scale = _float_arg(score_scale, "XCOMET_SCORE_SCALE", 1.0)
+    resolved_score_shift = _float_arg(score_shift, "XCOMET_SCORE_SHIFT", 0.0)
+    resolved_score_min = _float_arg(score_min, "XCOMET_SCORE_MIN", -1.0)
+    resolved_score_max = _float_arg(score_max, "XCOMET_SCORE_MAX", 1.0)
+    resolved_empty_score = _float_arg(empty_score, "XCOMET_EMPTY_SCORE", -0.3)
+    resolved_use_reference = _bool_arg(use_reference, "XCOMET_USE_REFERENCE", True)
+
+    if solution_strs is not None:
+        # Fill missing references and metadata to the batch length.
+        refs = ground_truths or [""] * len(solution_strs)
+        extras = extra_infos or [{} for _ in solution_strs]
+        return _score_batch(
+            [str(item or "") for item in solution_strs],
+            [str(item or "") for item in refs],
+            [dict(item or {}) for item in extras],
+            xcomet_urls=resolved_urls,
+            timeout_s=resolved_timeout_s,
+            retries=resolved_retries,
+            score_scale=resolved_score_scale,
+            score_shift=resolved_score_shift,
+            score_min=resolved_score_min,
+            score_max=resolved_score_max,
+            empty_score=resolved_empty_score,
+            use_reference=resolved_use_reference,
+        )
+
+    # Reuse the batch path for a single item and return its first result.
+    return _score_batch(
+        [solution_str or ""],
+        [ground_truth or ""],
+        [extra_info or {}],
+        xcomet_urls=resolved_urls,
+        timeout_s=resolved_timeout_s,
+        retries=resolved_retries,
+        score_scale=resolved_score_scale,
+        score_shift=resolved_score_shift,
+        score_min=resolved_score_min,
+        score_max=resolved_score_max,
+        empty_score=resolved_empty_score,
+        use_reference=resolved_use_reference,
+    )[0]

--- a/scripts/rl/run_grpo.sh
+++ b/scripts/rl/run_grpo.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_DIR=$(cd -- "${SCRIPT_DIR}/../.." && pwd)
+
+VERL_ROOT=${VERL_ROOT:-}
+MODEL_PATH=${MODEL_PATH:-}
+TRAIN_FILE=${TRAIN_FILE:-}
+VAL_FILE=${VAL_FILE:-}
+XCOMET_URLS=${XCOMET_URLS:-}
+COMETKIWI_URLS=${COMETKIWI_URLS:-}
+
+for required in VERL_ROOT MODEL_PATH TRAIN_FILE VAL_FILE XCOMET_URLS COMETKIWI_URLS; do
+    if [[ -z "${!required}" ]]; then
+        echo "Missing required environment variable: ${required}" >&2
+        exit 2
+    fi
+done
+
+[[ -f "${TRAIN_FILE}" ]] || { echo "Training file not found: ${TRAIN_FILE}" >&2; exit 2; }
+[[ -f "${VAL_FILE}" ]] || { echo "Validation file not found: ${VAL_FILE}" >&2; exit 2; }
+[[ -d "${VERL_ROOT}" ]] || { echo "verl directory not found: ${VERL_ROOT}" >&2; exit 2; }
+if [[ "${MODEL_PATH}" == /* && ! -d "${MODEL_PATH}" ]]; then
+    echo "Local model directory not found: ${MODEL_PATH}" >&2
+    exit 2
+fi
+
+NNODES=${NNODES:-1}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
+TRAIN_BATCH_SIZE=${TRAIN_BATCH_SIZE:-128}
+PPO_MINI_BATCH_SIZE=${PPO_MINI_BATCH_SIZE:-128}
+PPO_MICRO_BATCH_SIZE_PER_GPU=${PPO_MICRO_BATCH_SIZE_PER_GPU:-1}
+LOG_PROB_MICRO_BATCH_SIZE_PER_GPU=${LOG_PROB_MICRO_BATCH_SIZE_PER_GPU:-1}
+PPO_MAX_TOKEN_LEN_PER_GPU=${PPO_MAX_TOKEN_LEN_PER_GPU:-16384}
+MAX_PROMPT_LENGTH=${MAX_PROMPT_LENGTH:-4096}
+MAX_RESPONSE_LENGTH=${MAX_RESPONSE_LENGTH:-4096}
+ROLLOUT_MAX_MODEL_LEN=${ROLLOUT_MAX_MODEL_LEN:-8192}
+ROLLOUT_TP=${ROLLOUT_TP:-1}
+ROLLOUT_N=${ROLLOUT_N:-8}
+ROLLOUT_GPU_MEM_UTIL=${ROLLOUT_GPU_MEM_UTIL:-0.6}
+ROLLOUT_TEMPERATURE=${ROLLOUT_TEMPERATURE:-0.8}
+ROLLOUT_TOP_P=${ROLLOUT_TOP_P:-0.95}
+ROLLOUT_AGENT_NUM_WORKERS=${ROLLOUT_AGENT_NUM_WORKERS:-16}
+ACTOR_LR=${ACTOR_LR:-1e-6}
+KL_LOSS_COEF=${KL_LOSS_COEF:-0.001}
+ENTROPY_COEFF=${ENTROPY_COEFF:-0}
+ACTOR_PARAM_OFFLOAD=${ACTOR_PARAM_OFFLOAD:-False}
+ACTOR_OPTIMIZER_OFFLOAD=${ACTOR_OPTIMIZER_OFFLOAD:-False}
+REF_PARAM_OFFLOAD=${REF_PARAM_OFFLOAD:-True}
+TOTAL_EPOCHS=${TOTAL_EPOCHS:-3}
+SAVE_FREQ=${SAVE_FREQ:-238}
+TEST_FREQ=${TEST_FREQ:-50}
+VAL_BEFORE_TRAIN=${VAL_BEFORE_TRAIN:-True}
+TRAIN_MAX_SAMPLES=${TRAIN_MAX_SAMPLES:--1}
+VAL_MAX_SAMPLES=${VAL_MAX_SAMPLES:-1000}
+FILTER_OVERLONG_PROMPTS_WORKERS=${FILTER_OVERLONG_PROMPTS_WORKERS:-16}
+REWARD_NUM_WORKERS=${REWARD_NUM_WORKERS:-8}
+
+XCOMET_TIMEOUT_S=${XCOMET_TIMEOUT_S:-300}
+XCOMET_RETRIES=${XCOMET_RETRIES:--1}
+DUALCOMET_LA_FAIL_SCORE=${DUALCOMET_LA_FAIL_SCORE:-0.0}
+XCOMET_NO_KEEPALIVE=${XCOMET_NO_KEEPALIVE:-1}
+
+PROJECT_NAME=${PROJECT_NAME:-milmmt_grpo_mt}
+MODEL_SIZE_TAG=$(
+    basename "${MODEL_PATH}" \
+        | grep -oiE '[0-9]+\.?[0-9]*[bB]' \
+        | head -n1 \
+        | tr '[:upper:]' '[:lower:]' \
+        || true
+)
+MODEL_SIZE_TAG=${MODEL_SIZE_TAG:-unknown}
+DATA_TAG=$(basename "$(dirname "${TRAIN_FILE}")")
+EXPERIMENT_NAME=${EXPERIMENT_NAME:-milmmt_${MODEL_SIZE_TAG}_grpo_dualcometopenlid_${DATA_TAG}_$(date +%Y%m%d_%H%M)}
+OUTPUT_DIR=${OUTPUT_DIR:-${PROJECT_DIR}/outputs/${EXPERIMENT_NAME}}
+CHECKPOINT_DIR=${CHECKPOINT_DIR:-${PROJECT_DIR}/checkpoints/${PROJECT_NAME}/${EXPERIMENT_NAME}}
+LOGGER=${LOGGER:-'["console"]'}
+TENSORBOARD_DIR=${TENSORBOARD_DIR:-${PROJECT_DIR}/outputs/tensorboard}
+PLAIN_CHAT_TEMPLATE=${PLAIN_CHAT_TEMPLATE:-"{% for message in messages %}{{ message.content }}{% endfor %}"}
+REWARD_PATH=${REWARD_PATH:-${SCRIPT_DIR}/rewards/mt_dual_comet_reward.py}
+[[ -f "${REWARD_PATH}" ]] || { echo "Reward function not found: ${REWARD_PATH}" >&2; exit 2; }
+
+export PYTHONPATH="${VERL_ROOT}:${PYTHONPATH:-}"
+export TENSORBOARD_DIR
+export XCOMET_URLS COMETKIWI_URLS XCOMET_TIMEOUT_S XCOMET_RETRIES XCOMET_NO_KEEPALIVE
+export HF_HOME=${HF_HOME:-${PROJECT_DIR}/.cache/huggingface}
+export HF_DATASETS_CACHE=${HF_DATASETS_CACHE:-${HF_HOME}/datasets}
+export XDG_CACHE_HOME=${XDG_CACHE_HOME:-${PROJECT_DIR}/.cache}
+export WANDB_DIR=${WANDB_DIR:-${PROJECT_DIR}/wandb}
+
+mkdir -p "${HF_HOME}" "${HF_DATASETS_CACHE}" "${XDG_CACHE_HOME}/verl" \
+    "${PROJECT_DIR}/outputs" "${CHECKPOINT_DIR}"
+
+DATA=(
+    algorithm.adv_estimator=grpo
+    algorithm.use_kl_in_reward=False
+    data.train_files="${TRAIN_FILE}"
+    data.val_files="${VAL_FILE}"
+    data.train_batch_size=${TRAIN_BATCH_SIZE}
+    data.train_max_samples=${TRAIN_MAX_SAMPLES}
+    data.val_max_samples=${VAL_MAX_SAMPLES}
+    data.max_prompt_length=${MAX_PROMPT_LENGTH}
+    data.max_response_length=${MAX_RESPONSE_LENGTH}
+    data.filter_overlong_prompts=True
+    data.filter_overlong_prompts_workers=${FILTER_OVERLONG_PROMPTS_WORKERS}
+    data.truncation=error
+    data.shuffle=True
+    data.seed=42
+    "+data.cache_dir=${XDG_CACHE_HOME}/verl/rlhf"
+    "+data.apply_chat_template_kwargs.chat_template='${PLAIN_CHAT_TEMPLATE}'"
+)
+
+MODEL=(
+    actor_rollout_ref.model.path="${MODEL_PATH}"
+    actor_rollout_ref.model.use_remove_padding=True
+    actor_rollout_ref.model.enable_gradient_checkpointing=True
+    "actor_rollout_ref.model.custom_chat_template='${PLAIN_CHAT_TEMPLATE}'"
+)
+
+ACTOR=(
+    actor_rollout_ref.actor.optim.lr=${ACTOR_LR}
+    actor_rollout_ref.actor.ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE}
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=${PPO_MICRO_BATCH_SIZE_PER_GPU}
+    actor_rollout_ref.actor.use_dynamic_bsz=True
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU}
+    actor_rollout_ref.actor.use_kl_loss=True
+    actor_rollout_ref.actor.kl_loss_coef=${KL_LOSS_COEF}
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl
+    actor_rollout_ref.actor.entropy_coeff=${ENTROPY_COEFF}
+    actor_rollout_ref.actor.fsdp_config.param_offload=${ACTOR_PARAM_OFFLOAD}
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=${ACTOR_OPTIMIZER_OFFLOAD}
+)
+
+ROLLOUT=(
+    actor_rollout_ref.rollout.name=vllm
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${ROLLOUT_TP}
+    actor_rollout_ref.rollout.max_model_len=${ROLLOUT_MAX_MODEL_LEN}
+    actor_rollout_ref.rollout.gpu_memory_utilization=${ROLLOUT_GPU_MEM_UTIL}
+    actor_rollout_ref.rollout.n=${ROLLOUT_N}
+    actor_rollout_ref.rollout.temperature=${ROLLOUT_TEMPERATURE}
+    actor_rollout_ref.rollout.top_p=${ROLLOUT_TOP_P}
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=${LOG_PROB_MICRO_BATCH_SIZE_PER_GPU}
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU}
+    actor_rollout_ref.rollout.agent.num_workers=${ROLLOUT_AGENT_NUM_WORKERS}
+)
+
+REF=(
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=${LOG_PROB_MICRO_BATCH_SIZE_PER_GPU}
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU}
+    actor_rollout_ref.ref.fsdp_config.param_offload=${REF_PARAM_OFFLOAD}
+)
+
+REWARD=(
+    reward.num_workers=${REWARD_NUM_WORKERS}
+    reward.reward_manager.name=naive
+    reward.custom_reward_function.path="${REWARD_PATH}"
+    reward.custom_reward_function.name=compute_score
+    "+reward.custom_reward_function.reward_kwargs.xcomet_urls='${XCOMET_URLS}'"
+    "+reward.custom_reward_function.reward_kwargs.cometkiwi_urls='${COMETKIWI_URLS}'"
+    "+reward.custom_reward_function.reward_kwargs.timeout_s=${XCOMET_TIMEOUT_S}"
+    "+reward.custom_reward_function.reward_kwargs.retries=${XCOMET_RETRIES}"
+    "+reward.custom_reward_function.reward_kwargs.la_fail_score=${DUALCOMET_LA_FAIL_SCORE}"
+)
+
+TRAINER=(
+    trainer.balance_batch=True
+    trainer.critic_warmup=0
+    trainer.logger="${LOGGER}"
+    trainer.project_name="${PROJECT_NAME}"
+    trainer.experiment_name="${EXPERIMENT_NAME}"
+    trainer.n_gpus_per_node=${NGPUS_PER_NODE}
+    trainer.nnodes=${NNODES}
+    trainer.save_freq=${SAVE_FREQ}
+    trainer.test_freq=${TEST_FREQ}
+    trainer.total_epochs=${TOTAL_EPOCHS}
+    trainer.val_before_train=${VAL_BEFORE_TRAIN}
+    trainer.default_local_dir="${CHECKPOINT_DIR}"
+)
+
+RAY_ENV=()
+if [[ -n "${XCOMET_NO_KEEPALIVE}" ]]; then
+    RAY_ENV+=(
+        "+ray_kwargs.ray_init.runtime_env.env_vars.XCOMET_NO_KEEPALIVE='${XCOMET_NO_KEEPALIVE}'"
+    )
+fi
+
+cd "${VERL_ROOT}"
+python3 -m verl.trainer.main_ppo \
+    hydra.run.dir="${OUTPUT_DIR}" \
+    hydra.job.chdir=False \
+    "${DATA[@]}" \
+    "${MODEL[@]}" \
+    "${ACTOR[@]}" \
+    "${ROLLOUT[@]}" \
+    "${REF[@]}" \
+    "${REWARD[@]}" \
+    "${TRAINER[@]}" \
+    "${RAY_ENV[@]}" \
+    "$@"

--- a/scripts/rl/servers/openlid_gate.py
+++ b/scripts/rl/servers/openlid_gate.py
@@ -1,0 +1,144 @@
+"""OpenLID-v3 language gate used by the translation reward server."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import regex
+
+
+OPENLID_LANG_TO_CODE: dict[str, str] = {
+    "Arabic": "ara_Arab",
+    "Azerbaijani": "azj_Latn",
+    "Bengali": "ben_Beng",
+    "Bulgarian": "bul_Cyrl",
+    "Burmese": "mya_Mymr",
+    "Cantonese": "yue_Hant",
+    "Catalan": "cat_Latn",
+    "Chinese (Simplified)": "cmn_Hans",
+    "Chinese (Traditional)": "cmn_Hant",
+    "Croatian": "hrv_Latn",
+    "Czech": "ces_Latn",
+    "Danish": "dan_Latn",
+    "Dutch": "nld_Latn",
+    "English": "eng_Latn",
+    "Finnish": "fin_Latn",
+    "French": "fra_Latn",
+    "German": "deu_Latn",
+    "Greek": "ell_Grek",
+    "Hebrew": "heb_Hebr",
+    "Hindi": "hin_Deva",
+    "Hungarian": "hun_Latn",
+    "Indonesian": "ind_Latn",
+    "Italian": "ita_Latn",
+    "Japanese": "jpn_Jpan",
+    "Kazakh": "kaz_Cyrl",
+    "Khmer": "khm_Khmr",
+    "Korean": "kor_Hang",
+    "Lao": "lao_Laoo",
+    "Malay": "zsm_Latn",
+    "Norwegian": "nob_Latn",
+    "Persian": "fas_Arab",
+    "Polish": "pol_Latn",
+    "Portuguese": "por_Latn",
+    "Romanian": "ron_Latn",
+    "Russian": "rus_Cyrl",
+    "Slovak": "slk_Latn",
+    "Slovenian": "slv_Latn",
+    "Spanish": "spa_Latn",
+    "Swedish": "swe_Latn",
+    "Tagalog": "fil_Latn",
+    "Tamil": "tam_Taml",
+    "Thai": "tha_Thai",
+    "Turkish": "tur_Latn",
+    "Urdu": "urd_Arab",
+    "Uzbek": "uzn_Latn",
+    "Vietnamese": "vie_Latn",
+}
+
+_NONWORD_PATTERN = regex.compile(r"[^\p{Word}\p{Zs}]|\d")
+_SPACE_PATTERN = regex.compile(r"\s\s+")
+
+
+def target_language_to_openlid_code(target_language: str | None) -> str | None:
+    """Map a MiLMMT target-language name to an OpenLID language/script code."""
+    if not target_language:
+        return None
+    name = target_language.strip()
+    if name in OPENLID_LANG_TO_CODE:
+        return OPENLID_LANG_TO_CODE[name]
+    base = re.sub(r"\s*\(.*?\)\s*", "", name).strip()
+    if base in OPENLID_LANG_TO_CODE:
+        return OPENLID_LANG_TO_CODE[base]
+    head = base.split()[0] if base else ""
+    return OPENLID_LANG_TO_CODE.get(head)
+
+
+def preprocess_openlid(text: str) -> str:
+    """Apply the preprocessing used by OpenLID-v3 before prediction."""
+    normalized = (text or "").strip().replace("\n", " ").lower()
+    normalized = _SPACE_PATTERN.sub(" ", normalized)
+    return _NONWORD_PATTERN.sub("", normalized)
+
+
+class OpenLIDGate:
+    """Batch OpenLID predictor with exact language/script matching."""
+
+    def __init__(self, model_path: str | Path, model: Any | None = None):
+        if model is None:
+            import fasttext
+
+            model_path = Path(model_path)
+            if not model_path.is_file():
+                raise FileNotFoundError(f"OpenLID model not found: {model_path}")
+            model = fasttext.load_model(str(model_path))
+        self.model = model
+
+    @staticmethod
+    def _label_code(label: str) -> str:
+        return label.replace("__label__", "")
+
+    def evaluate_batch(
+        self,
+        translations: list[str],
+        target_languages: list[str | None],
+    ) -> list[dict[str, Any]]:
+        if len(translations) != len(target_languages):
+            raise ValueError(
+                "translations and target_languages must have the same length: "
+                f"{len(translations)} != {len(target_languages)}"
+            )
+        if not translations:
+            return []
+
+        target_codes = [target_language_to_openlid_code(language) for language in target_languages]
+        cleaned = [preprocess_openlid(text) for text in translations]
+        safe_inputs = [text if text else " " for text in cleaned]
+        labels_batch, _ = self.model.predict(safe_inputs, k=1)
+
+        results: list[dict[str, Any]] = []
+        for index, target_code in enumerate(target_codes):
+            if target_code is None:
+                results.append(
+                    {
+                        "la_ok": 1,
+                        "la_skip": 1,
+                        "pred_iso": "",
+                        "tgt_iso": "",
+                    }
+                )
+                continue
+
+            labels = labels_batch[index]
+            predicted_code = self._label_code(labels[0]) if labels and cleaned[index] else ""
+            results.append(
+                {
+                    "la_ok": int(predicted_code == target_code),
+                    "la_skip": 0,
+                    "pred_iso": predicted_code,
+                    "tgt_iso": target_code,
+                }
+            )
+        return results

--- a/scripts/rl/servers/qe_server.py
+++ b/scripts/rl/servers/qe_server.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""Serve COMET QE scores with an optional OpenLID language-gated endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import dataclasses
+import logging
+import os
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import torch
+import uvicorn
+from comet import load_from_checkpoint
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+try:
+    from .openlid_gate import OpenLIDGate
+except ImportError:
+    from openlid_gate import OpenLIDGate
+
+
+LOGGER = logging.getLogger("qe_server")
+
+
+class TranslationItem(BaseModel):
+    src: str
+    mt: str
+    ref: str | None = None
+
+
+class ScoreRequest(BaseModel):
+    items: list[TranslationItem]
+
+
+class OpenLIDItem(BaseModel):
+    src: str
+    mt: str
+    tgt_lang: str | None = None
+
+
+class OpenLIDRequest(BaseModel):
+    items: list[OpenLIDItem]
+
+
+def resolve_checkpoint(model_path: str) -> str:
+    root = Path(model_path)
+    if root.is_file():
+        return str(root)
+    if not root.is_dir():
+        raise FileNotFoundError(f"COMET model path not found: {root}")
+    default_checkpoint = root / "checkpoints" / "model.ckpt"
+    if default_checkpoint.is_file():
+        return str(default_checkpoint)
+    matches = sorted(root.rglob("*.ckpt"))
+    if matches:
+        return str(matches[0])
+    raise FileNotFoundError(f"Could not find a .ckpt under {root}")
+
+
+def configure_hf_cache(hf_cache: str | None, set_hub_cache: bool) -> None:
+    if not hf_cache:
+        return
+    cache = str(Path(hf_cache))
+    os.environ.setdefault("HF_HOME", cache)
+    if set_hub_cache:
+        os.environ.setdefault("HUGGINGFACE_HUB_CACHE", cache)
+
+
+def to_jsonable(value: Any) -> Any:
+    if dataclasses.is_dataclass(value):
+        return to_jsonable(dataclasses.asdict(value))
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu().tolist()
+    if isinstance(value, dict):
+        return {str(key): to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [to_jsonable(item) for item in value]
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    if hasattr(value, "__dict__") and not isinstance(value, (str, bytes)):
+        return to_jsonable(vars(value))
+    return value
+
+
+def move_to_device(value: Any, device: torch.device) -> Any:
+    if isinstance(value, torch.Tensor):
+        return value.to(device)
+    if isinstance(value, dict):
+        return {key: move_to_device(item, device) for key, item in value.items()}
+    if isinstance(value, list):
+        return [move_to_device(item, device) for item in value]
+    if isinstance(value, tuple):
+        return tuple(move_to_device(item, device) for item in value)
+    return value
+
+
+def prediction_get(prediction: Any, key: str, default: Any = None) -> Any:
+    if isinstance(prediction, dict):
+        return prediction.get(key, default)
+    return getattr(prediction, key, default)
+
+
+class RequestBatcher:
+    """Combine concurrent HTTP requests before running a synchronous scorer."""
+
+    def __init__(
+        self,
+        process: Callable[[list[dict[str, str]]], list[dict[str, Any]]],
+        *,
+        name: str,
+        max_wait_ms: int,
+        max_batch_size: int,
+        slow_request_ms: int,
+    ):
+        self.process = process
+        self.name = name
+        self.max_wait_ms = max_wait_ms
+        self.max_batch_size = max_batch_size
+        self.slow_request_ms = slow_request_ms
+        self.pending: list[tuple[list[dict[str, str]], asyncio.Future, float]] = []
+        self.pending_lock = asyncio.Lock()
+        self.process_lock = asyncio.Lock()
+        self.flush_task: asyncio.Task | None = None
+        self.request_total = 0
+        self.item_total = 0
+        self.flush_total = 0
+        self.slow_total = 0
+        self.max_pending_depth = 0
+        self.max_queue_wait = 0.0
+
+    async def score(self, items: list[dict[str, str]]) -> list[dict[str, Any]]:
+        if not items:
+            return []
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future = loop.create_future()
+        enqueued_at = time.perf_counter()
+        async with self.pending_lock:
+            self.pending.append((items, future, enqueued_at))
+            total = sum(len(batch) for batch, _, _ in self.pending)
+            self.max_pending_depth = max(self.max_pending_depth, len(self.pending))
+            if self.flush_task is None or self.flush_task.done():
+                self.flush_task = asyncio.create_task(self._delayed_flush())
+            if total >= self.max_batch_size:
+                asyncio.create_task(self._flush())
+
+        result = await future
+        elapsed_ms = (time.perf_counter() - enqueued_at) * 1000
+        if elapsed_ms >= self.slow_request_ms:
+            self.slow_total += 1
+            LOGGER.warning(
+                "Slow %s request: %d item(s) took %.0fms (slow_total=%d)",
+                self.name,
+                len(items),
+                elapsed_ms,
+                self.slow_total,
+            )
+        return result
+
+    async def _delayed_flush(self) -> None:
+        await asyncio.sleep(self.max_wait_ms / 1000)
+        await self._flush()
+
+    async def _flush(self) -> None:
+        async with self.pending_lock:
+            pending = self.pending
+            self.pending = []
+        if not pending:
+            return
+
+        flat_items = [item for batch, _, _ in pending for item in batch]
+        started = time.perf_counter()
+        queue_wait = max(started - enqueued_at for _, _, enqueued_at in pending)
+        self.max_queue_wait = max(self.max_queue_wait, queue_wait)
+        try:
+            async with self.process_lock:
+                loop = asyncio.get_running_loop()
+                flat_results = await loop.run_in_executor(None, self.process, flat_items)
+            if len(flat_results) != len(flat_items):
+                raise RuntimeError(
+                    f"{self.name} returned {len(flat_results)} results for {len(flat_items)} items"
+                )
+        except Exception as error:
+            LOGGER.exception("%s failed for %d item(s)", self.name, len(flat_items))
+            for _, future, _ in pending:
+                if not future.done():
+                    future.set_exception(error)
+            return
+
+        elapsed = time.perf_counter() - started
+        self.request_total += len(pending)
+        self.item_total += len(flat_items)
+        self.flush_total += 1
+        LOGGER.info(
+            "%s scored %d item(s) from %d request(s) in %.3fs (%.1f item/s)",
+            self.name,
+            len(flat_items),
+            len(pending),
+            elapsed,
+            len(flat_items) / elapsed if elapsed > 0 else float("inf"),
+        )
+
+        cursor = 0
+        for batch, future, _ in pending:
+            size = len(batch)
+            if not future.done():
+                future.set_result(flat_results[cursor : cursor + size])
+            cursor += size
+
+        async with self.pending_lock:
+            if self.pending and (
+                self.flush_task is None
+                or self.flush_task.done()
+                or self.flush_task is asyncio.current_task()
+            ):
+                self.flush_task = asyncio.create_task(self._delayed_flush())
+
+    def stats(self) -> dict[str, Any]:
+        return {
+            "flushes": self.flush_total,
+            "requests": self.request_total,
+            "items": self.item_total,
+            "slow_requests": self.slow_total,
+            "max_pending_depth": self.max_pending_depth,
+            "max_queue_wait_s": round(self.max_queue_wait, 3),
+        }
+
+
+class CometPredictor:
+    """Run direct COMET ``predict_step`` inference in bounded GPU batches."""
+
+    def __init__(self, model: Any, device: torch.device, predict_batch_size: int):
+        self.model = model
+        self.device = device
+        self.predict_batch_size = predict_batch_size
+
+    def __call__(self, items: list[dict[str, str]]) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        for start in range(0, len(items), self.predict_batch_size):
+            batch_items = items[start : start + self.predict_batch_size]
+            prepared = self.model.prepare_for_inference(batch_items)
+            prepared = move_to_device(prepared, self.device)
+            with torch.inference_mode():
+                prediction = self.model.predict_step(
+                    prepared,
+                    batch_idx=start // self.predict_batch_size,
+                )
+
+            scores = to_jsonable(prediction_get(prediction, "scores", []))
+            metadata = prediction_get(prediction, "metadata", {})
+            error_spans = to_jsonable(
+                prediction_get(metadata, "error_spans", [[] for _ in scores])
+            )
+            if not isinstance(error_spans, list) or len(error_spans) != len(scores):
+                error_spans = [[] for _ in scores]
+            for index, score in enumerate(scores):
+                results.append(
+                    {
+                        "score": float(score),
+                        "error_spans": error_spans[index],
+                    }
+                )
+        return results
+
+
+def build_app(
+    predictor: CometPredictor,
+    *,
+    checkpoint: str,
+    device: str,
+    max_wait_ms: int,
+    max_server_batch_size: int,
+    slow_request_ms: int,
+    openlid_gate: OpenLIDGate | None = None,
+    openlid_max_wait_ms: int = 20,
+    openlid_max_batch_size: int = 64,
+) -> FastAPI:
+    score_batcher = RequestBatcher(
+        predictor,
+        name="COMET QE",
+        max_wait_ms=max_wait_ms,
+        max_batch_size=max_server_batch_size,
+        slow_request_ms=slow_request_ms,
+    )
+    openlid_batcher = None
+    if openlid_gate is not None:
+
+        def evaluate_openlid(items: list[dict[str, str]]) -> list[dict[str, Any]]:
+            return openlid_gate.evaluate_batch(
+                [item.get("mt", "") for item in items],
+                [item.get("tgt_lang") for item in items],
+            )
+
+        openlid_batcher = RequestBatcher(
+            evaluate_openlid,
+            name="OpenLID",
+            max_wait_ms=openlid_max_wait_ms,
+            max_batch_size=openlid_max_batch_size,
+            slow_request_ms=slow_request_ms,
+        )
+
+    app = FastAPI(title="COMET QE reward server")
+
+    @app.get("/health")
+    async def health() -> dict[str, Any]:
+        return {
+            "ok": True,
+            "checkpoint": checkpoint,
+            "device": device,
+            "openlid": openlid_batcher is not None,
+            "score_stats": score_batcher.stats(),
+            "openlid_stats": openlid_batcher.stats() if openlid_batcher else None,
+        }
+
+    @app.post("/score")
+    async def score(request: ScoreRequest) -> dict[str, Any]:
+        try:
+            items = [item.model_dump(exclude_none=True) for item in request.items]
+            return {"results": await score_batcher.score(items)}
+        except Exception as error:
+            LOGGER.exception("COMET /score failed for %d item(s)", len(request.items))
+            raise HTTPException(status_code=500, detail=str(error)) from error
+
+    @app.post("/score_openlid")
+    async def score_openlid(request: OpenLIDRequest) -> dict[str, Any]:
+        if openlid_batcher is None:
+            raise HTTPException(status_code=400, detail="OpenLID is not enabled on this server")
+        try:
+            items = [item.model_dump() for item in request.items]
+            qe_items = [{"src": item["src"], "mt": item["mt"]} for item in items]
+            qe_results, openlid_results = await asyncio.gather(
+                score_batcher.score(qe_items),
+                openlid_batcher.score(items),
+            )
+            results = []
+            for qe_result, openlid_result in zip(
+                qe_results,
+                openlid_results,
+                strict=True,
+            ):
+                results.append(
+                    {
+                        "qe": float(qe_result.get("score", 0.0)),
+                        "wa": 0.0,
+                        "la_ok": int(openlid_result["la_ok"]),
+                        "la_skip": int(openlid_result["la_skip"]),
+                        "wa_precision": 0.0,
+                        "wa_recall": 0.0,
+                        "pred_iso": openlid_result.get("pred_iso", ""),
+                        "tgt_iso": openlid_result.get("tgt_iso", ""),
+                        "error_spans": qe_result.get("error_spans", []),
+                    }
+                )
+            return {"results": results}
+        except HTTPException:
+            raise
+        except Exception as error:
+            LOGGER.exception("COMET /score_openlid failed for %d item(s)", len(request.items))
+            raise HTTPException(status_code=500, detail=str(error)) from error
+
+    return app
+
+
+def create_app(args: argparse.Namespace) -> FastAPI:
+    checkpoint = resolve_checkpoint(args.model)
+    configure_hf_cache(args.hf_cache, set_hub_cache=args.hf_hub_cache)
+    device = torch.device(args.device)
+
+    LOGGER.info("Loading COMET checkpoint: %s", checkpoint)
+    model = load_from_checkpoint(checkpoint, local_files_only=args.local_files_only)
+    model.eval()
+    model.to(device)
+    if hasattr(model, "input_weights_spans") and isinstance(
+        model.input_weights_spans,
+        torch.Tensor,
+    ):
+        model.input_weights_spans = model.input_weights_spans.to(device)
+
+    predictor = CometPredictor(model, device, args.predict_batch_size)
+    openlid_gate = OpenLIDGate(args.openlid_model) if args.openlid_model else None
+    return build_app(
+        predictor,
+        checkpoint=checkpoint,
+        device=str(device),
+        max_wait_ms=args.max_wait_ms,
+        max_server_batch_size=args.max_server_batch_size,
+        slow_request_ms=args.slow_request_ms,
+        openlid_gate=openlid_gate,
+        openlid_max_wait_ms=args.openlid_max_wait_ms,
+        openlid_max_batch_size=args.openlid_max_batch_size,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Serve COMET QE scores with an optional OpenLID gate."
+    )
+    parser.add_argument("--model", required=True, help="local COMET checkpoint file or model directory")
+    parser.add_argument("--openlid-model", help="local OpenLID-v3 fastText model")
+    parser.add_argument("--hf-cache", default=os.getenv("HF_HOME"))
+    parser.add_argument(
+        "--hf-hub-cache",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="also set HUGGINGFACE_HUB_CACHE to --hf-cache",
+    )
+    parser.add_argument(
+        "--local-files-only",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8008)
+    parser.add_argument("--device", default="cuda:0" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--predict-batch-size", type=int, default=8)
+    parser.add_argument("--max-server-batch-size", type=int, default=32)
+    parser.add_argument("--max-wait-ms", type=int, default=50)
+    parser.add_argument("--openlid-max-wait-ms", type=int, default=20)
+    parser.add_argument("--openlid-max-batch-size", type=int, default=64)
+    parser.add_argument("--slow-request-ms", type=int, default=3000)
+    parser.add_argument("--log-level", default="info")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper()),
+        format="%(asctime)s.%(msecs)03d %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    with contextlib.suppress(Exception):
+        torch.set_float32_matmul_precision("high")
+    uvicorn.run(
+        create_app(args),
+        host=args.host,
+        port=args.port,
+        log_level=args.log_level,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rl/servers/run_qe_server.sh
+++ b/scripts/rl/servers/run_qe_server.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+QE_MODEL_PATH=${QE_MODEL_PATH:-}
+if [[ -z "${QE_MODEL_PATH}" ]]; then
+    echo "Missing required environment variable: QE_MODEL_PATH" >&2
+    exit 2
+fi
+if [[ ! -e "${QE_MODEL_PATH}" ]]; then
+    echo "COMET model path not found: ${QE_MODEL_PATH}" >&2
+    exit 2
+fi
+
+OPENLID_MODEL_PATH=${OPENLID_MODEL_PATH:-}
+if [[ -n "${OPENLID_MODEL_PATH}" && ! -f "${OPENLID_MODEL_PATH}" ]]; then
+    echo "OpenLID model not found: ${OPENLID_MODEL_PATH}" >&2
+    exit 2
+fi
+
+QE_HOST=${QE_HOST:-127.0.0.1}
+QE_PORT=${QE_PORT:-8008}
+QE_DEVICE=${QE_DEVICE:-cuda:0}
+QE_PREDICT_BATCH_SIZE=${QE_PREDICT_BATCH_SIZE:-32}
+QE_MAX_SERVER_BATCH_SIZE=${QE_MAX_SERVER_BATCH_SIZE:-32}
+QE_MAX_WAIT_MS=${QE_MAX_WAIT_MS:-20}
+QE_OPENLID_MAX_WAIT_MS=${QE_OPENLID_MAX_WAIT_MS:-20}
+QE_OPENLID_MAX_BATCH_SIZE=${QE_OPENLID_MAX_BATCH_SIZE:-64}
+QE_SLOW_REQUEST_MS=${QE_SLOW_REQUEST_MS:-3000}
+QE_LOG_LEVEL=${QE_LOG_LEVEL:-info}
+QE_HF_CACHE=${QE_HF_CACHE:-${HF_HOME:-}}
+QE_SET_HF_HUB_CACHE=${QE_SET_HF_HUB_CACHE:-1}
+QE_LOCAL_FILES_ONLY=${QE_LOCAL_FILES_ONLY:-1}
+
+ARGS=(
+    --model "${QE_MODEL_PATH}"
+    --host "${QE_HOST}"
+    --port "${QE_PORT}"
+    --device "${QE_DEVICE}"
+    --predict-batch-size "${QE_PREDICT_BATCH_SIZE}"
+    --max-server-batch-size "${QE_MAX_SERVER_BATCH_SIZE}"
+    --max-wait-ms "${QE_MAX_WAIT_MS}"
+    --openlid-max-wait-ms "${QE_OPENLID_MAX_WAIT_MS}"
+    --openlid-max-batch-size "${QE_OPENLID_MAX_BATCH_SIZE}"
+    --slow-request-ms "${QE_SLOW_REQUEST_MS}"
+    --log-level "${QE_LOG_LEVEL}"
+)
+
+if [[ -n "${OPENLID_MODEL_PATH}" ]]; then
+    ARGS+=(--openlid-model "${OPENLID_MODEL_PATH}")
+fi
+if [[ -n "${QE_HF_CACHE}" ]]; then
+    ARGS+=(--hf-cache "${QE_HF_CACHE}")
+fi
+if [[ "${QE_SET_HF_HUB_CACHE}" == "0" ]]; then
+    unset HUGGINGFACE_HUB_CACHE || true
+    ARGS+=(--no-hf-hub-cache)
+fi
+if [[ "${QE_LOCAL_FILES_ONLY}" == "0" ]]; then
+    ARGS+=(--no-local-files-only)
+fi
+
+export PYTHONUNBUFFERED=1
+exec python3 "${SCRIPT_DIR}/qe_server.py" "${ARGS[@]}"

--- a/scripts/rl/servers/start_reward_servers.sh
+++ b/scripts/rl/servers/start_reward_servers.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+XCOMET_MODEL_PATH=${XCOMET_MODEL_PATH:-}
+COMETKIWI_MODEL_PATH=${COMETKIWI_MODEL_PATH:-}
+OPENLID_MODEL_PATH=${OPENLID_MODEL_PATH:-}
+
+for required in XCOMET_MODEL_PATH COMETKIWI_MODEL_PATH OPENLID_MODEL_PATH; do
+    if [[ -z "${!required}" ]]; then
+        echo "Missing required environment variable: ${required}" >&2
+        exit 2
+    fi
+done
+
+XCOMET_DEVICES=${XCOMET_DEVICES:-0}
+COMETKIWI_DEVICES=${COMETKIWI_DEVICES:-1}
+XCOMET_BASE_PORT=${XCOMET_BASE_PORT:-8008}
+COMETKIWI_BASE_PORT=${COMETKIWI_BASE_PORT:-8012}
+REWARD_HOST=${REWARD_HOST:-0.0.0.0}
+REWARD_ADVERTISE_HOST=${REWARD_ADVERTISE_HOST:-127.0.0.1}
+
+IFS=',' read -r -a XCOMET_DEVICE_LIST <<< "${XCOMET_DEVICES}"
+IFS=',' read -r -a COMETKIWI_DEVICE_LIST <<< "${COMETKIWI_DEVICES}"
+if [[ ${#XCOMET_DEVICE_LIST[@]} -eq 0 || ${#COMETKIWI_DEVICE_LIST[@]} -eq 0 ]]; then
+    echo "Both XCOMET_DEVICES and COMETKIWI_DEVICES must list at least one GPU." >&2
+    exit 2
+fi
+XCOMET_LAST_PORT=$((XCOMET_BASE_PORT + ${#XCOMET_DEVICE_LIST[@]} - 1))
+COMETKIWI_LAST_PORT=$((COMETKIWI_BASE_PORT + ${#COMETKIWI_DEVICE_LIST[@]} - 1))
+if (( XCOMET_BASE_PORT <= COMETKIWI_LAST_PORT && COMETKIWI_BASE_PORT <= XCOMET_LAST_PORT )); then
+    echo "xCOMET and CometKiwi port ranges overlap; adjust XCOMET_BASE_PORT or COMETKIWI_BASE_PORT." >&2
+    exit 2
+fi
+
+XCOMET_PREDICT_BATCH_SIZE=${XCOMET_PREDICT_BATCH_SIZE:-32}
+XCOMET_MAX_SERVER_BATCH_SIZE=${XCOMET_MAX_SERVER_BATCH_SIZE:-32}
+COMETKIWI_PREDICT_BATCH_SIZE=${COMETKIWI_PREDICT_BATCH_SIZE:-32}
+COMETKIWI_MAX_SERVER_BATCH_SIZE=${COMETKIWI_MAX_SERVER_BATCH_SIZE:-32}
+XCOMET_SET_HF_HUB_CACHE=${XCOMET_SET_HF_HUB_CACHE:-1}
+COMETKIWI_SET_HF_HUB_CACHE=${COMETKIWI_SET_HF_HUB_CACHE:-1}
+
+PIDS=()
+XCOMET_ENDPOINTS=()
+COMETKIWI_ENDPOINTS=()
+
+cleanup() {
+    trap - EXIT INT TERM
+    for pid in "${PIDS[@]:-}"; do
+        if kill -0 "${pid}" 2>/dev/null; then
+            kill -TERM "${pid}" 2>/dev/null || true
+        fi
+    done
+    wait "${PIDS[@]:-}" 2>/dev/null || true
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+for index in "${!XCOMET_DEVICE_LIST[@]}"; do
+    device=${XCOMET_DEVICE_LIST[$index]// /}
+    port=$((XCOMET_BASE_PORT + index))
+    CUDA_VISIBLE_DEVICES="${device}" \
+        QE_MODEL_PATH="${XCOMET_MODEL_PATH}" \
+        OPENLID_MODEL_PATH="${OPENLID_MODEL_PATH}" \
+        QE_HOST="${REWARD_HOST}" \
+        QE_PORT="${port}" \
+        QE_DEVICE=cuda:0 \
+        QE_PREDICT_BATCH_SIZE="${XCOMET_PREDICT_BATCH_SIZE}" \
+        QE_MAX_SERVER_BATCH_SIZE="${XCOMET_MAX_SERVER_BATCH_SIZE}" \
+        QE_SET_HF_HUB_CACHE="${XCOMET_SET_HF_HUB_CACHE}" \
+        bash "${SCRIPT_DIR}/run_qe_server.sh" &
+    PIDS+=("$!")
+    XCOMET_ENDPOINTS+=("http://${REWARD_ADVERTISE_HOST}:${port}/score_openlid")
+done
+
+for index in "${!COMETKIWI_DEVICE_LIST[@]}"; do
+    device=${COMETKIWI_DEVICE_LIST[$index]// /}
+    port=$((COMETKIWI_BASE_PORT + index))
+    CUDA_VISIBLE_DEVICES="${device}" \
+        QE_MODEL_PATH="${COMETKIWI_MODEL_PATH}" \
+        OPENLID_MODEL_PATH= \
+        QE_HOST="${REWARD_HOST}" \
+        QE_PORT="${port}" \
+        QE_DEVICE=cuda:0 \
+        QE_PREDICT_BATCH_SIZE="${COMETKIWI_PREDICT_BATCH_SIZE}" \
+        QE_MAX_SERVER_BATCH_SIZE="${COMETKIWI_MAX_SERVER_BATCH_SIZE}" \
+        QE_SET_HF_HUB_CACHE="${COMETKIWI_SET_HF_HUB_CACHE}" \
+        bash "${SCRIPT_DIR}/run_qe_server.sh" &
+    PIDS+=("$!")
+    COMETKIWI_ENDPOINTS+=("http://${REWARD_ADVERTISE_HOST}:${port}/score")
+done
+
+printf -v XCOMET_URLS '%s,' "${XCOMET_ENDPOINTS[@]}"
+printf -v COMETKIWI_URLS '%s,' "${COMETKIWI_ENDPOINTS[@]}"
+echo "Reward servers started. Use these training variables:"
+echo "XCOMET_URLS=${XCOMET_URLS%,}"
+echo "COMETKIWI_URLS=${COMETKIWI_URLS%,}"
+
+set +e
+wait -n "${PIDS[@]}"
+status=$?
+set -e
+if [[ ${status} -eq 0 ]]; then
+    status=1
+fi
+echo "A reward server exited; stopping the remaining processes." >&2
+exit "${status}"


### PR DESCRIPTION
## Summary

Adds a reinforcement-learning training pipeline under `scripts/rl`, extending the existing SFT workflow:

- **GRPO launcher and reward client** — `scripts/rl/run_grpo.sh`, backed by xCOMET and CometKiwi reward functions in `scripts/rl/rewards/`.
- **Batched reward services** — `scripts/rl/servers/` hosts persistent COMET QE services with an OpenLID language gate, so reward workers reuse one loaded model instead of loading a copy per worker.
- **verl checkpoint export** — `scripts/rl/export_hf_checkpoint.sh` converts an FSDP actor checkpoint to Hugging Face format.
- **SFT/RL weight interpolation** — `scripts/rl/linear_merge.py` linearly merges SFT and RL weights.

Also includes an RL data example (`examples/rl.json`), a `scripts/rl/README.md` with setup and usage, and `.gitignore` entries for Python caches and training artifacts.

## Notes

- Reward scoring depends on external HTTP services (xCOMET/OpenLID, CometKiwi); no reward models are loaded in the client.
- `scripts/rl/README.md` documents installation, input schema, reward-service deployment, and example commands.
