### PR TITLE
Restructure Training section and relocate linear_merge.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 ## 📰 Updates
 
+* **Aug. xx 2026**: The MiLMMT-v1.0 paper [Reference-Free Post-Training of Open Large Language Models for Multilingual Machine Translation]() is available on ArXiv!
 * **Feb. 12 2026**: The MiLMMT-v0.1 paper [Scaling Model and Data for Multilingual Machine Translation with Open Large Language Models](https://arxiv.org/abs/2602.11961) is available on ArXiv!
 * **Jan. 23 2025**: The GemmaX2 paper [Multilingual Machine Translation with Open Large Language Models at Practical Scale: An Empirical Study](https://arxiv.org/abs/2502.02481) has been accepted at **NAACL 2025**!
 
@@ -104,7 +105,9 @@ print(tokenizer.decode(outputs[0], skip_special_tokens=True))
 
 ## 🏋️ Training
 
-We use [LlamaFactory](https://github.com/hiyouga/LlamaFactory) for continual pretraining and supervised finetuning. See the [LlamaFactory data docs](https://github.com/hiyouga/LlamaFactory/tree/main/data) for how to register those datasets. Remember to add your dataset to `dataset_info.json` before training.
+We use [LlamaFactory](https://github.com/hiyouga/LlamaFactory) for continual pretraining and supervised finetuning, and [verl](https://github.com/volcengine/verl) for reinforcement learning. 
+
+See the [LlamaFactory data docs](https://github.com/hiyouga/LlamaFactory/tree/main/data) for how to register those datasets. Remember to add your dataset to `dataset_info.json` before training.
 
 ### Continual Pretraining
 
@@ -122,20 +125,42 @@ Data samples for translation instruction finetuning are in [`examples/sft.json`]
 bash scripts/sft.sh
 ```
 
-### Reinforcement Learning and Model Merging
+### Reinforcement Learning
 
-MiLMMT-46-v1.0 adds GRPO fine-tuning with [verl](https://github.com/volcengine/verl), exports the resulting FSDP actor checkpoint to Hugging Face format, and linearly interpolates the SFT and RL weights.
+An example of the RL input format is in [`examples/rl.json`](examples/rl.json). The pipeline scripts are:
 
 - GRPO launcher and reward client: [`scripts/rl/run_grpo.sh`](scripts/rl/run_grpo.sh)
 - Batched xCOMET/OpenLID and CometKiwi services: [`scripts/rl/servers`](scripts/rl/servers)
-- `verl` checkpoint export: [`scripts/rl/export_hf_checkpoint.sh`](scripts/rl/export_hf_checkpoint.sh)
-- SFT/RL weight interpolation: [`scripts/rl/linear_merge.py`](scripts/rl/linear_merge.py)
 
-See [`scripts/rl/README.md`](scripts/rl/README.md) for installation, input schema, reward-service deployment, APIs, and example commands.
+See [`scripts/rl/README.md`](scripts/rl/README.md) for installation, reward-service deployment, and the full launch command.
+
+### Model Merging
+
+After RL training, linearly interpolate the SFT and RL weights:
+
+```bash
+python3 scripts/linear_merge.py \
+  --model_a /path/to/MiLMMT-46-12B-v0.1 \
+  --model_b /path/to/MiLMMT-46-12B-v0.1-RL \
+  --alpha 0.5 \
+  --out /path/to/MiLMMT-46-12B-v1.0
+```
 
 ## 📚 Reference
 
 If you find the resources in this repository helpful, please cite:
+
+```bibtex
+@misc{,
+      title={Reference-Free Post-Training of Open Large Language Models for Multilingual Machine Translation}, 
+      author={Chris Han and Pengzhi Gao and Pei Fu and Jian Luan},
+      year={2026},
+      eprint={},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={}, 
+}
+```
 
 ```bibtex
 @misc{shang2026scalingmodeldatamultilingual,

--- a/scripts/linear_merge.py
+++ b/scripts/linear_merge.py
@@ -9,6 +9,11 @@ Both inputs must use the same architecture and safetensors parameter names.
 Tensors are processed shard by shard, and the output shard layout and metadata
 follow the RL checkpoint. Gemma 3 tied embeddings are written without a
 separate ``lm_head.weight`` tensor.
+
+``alpha`` must be finite and within ``[0, 1]``; values outside this range are
+rejected. The output directory must not already exist unless ``--overwrite`` is
+supplied. The merged checkpoint includes a ``merge_manifest.json`` recording the
+formula, weights, and inputs.
 """
 
 from __future__ import annotations

--- a/scripts/rl/README.md
+++ b/scripts/rl/README.md
@@ -1,4 +1,4 @@
-# GRPO Fine-tuning and Model Merging
+# GRPO Fine-tuning
 
 This directory contains the code used for the MiLMMT-46 reinforcement-learning workflow:
 
@@ -8,7 +8,6 @@ This directory contains the code used for the MiLMMT-46 reinforcement-learning w
 - `servers/run_qe_server.sh`: launch one xCOMET or CometKiwi service process.
 - `servers/start_reward_servers.sh`: launch xCOMET/OpenLID and CometKiwi GPU pools.
 - `export_hf_checkpoint.sh`: convert a sharded `verl` FSDP actor checkpoint to Hugging Face format.
-- `linear_merge.py`: linearly interpolate the SFT and RL Hugging Face checkpoints.
 
 ## Environment
 
@@ -206,26 +205,3 @@ bash scripts/rl/export_hf_checkpoint.sh /path/to/experiment
 The default output is `/path/to/experiment/merged_hf_step<STEP>`. Set `TARGET_DIR` to choose another directory.
 `BASE_MODEL_DIR` is only used to restore missing processor configuration files for multimodal Gemma 3 checkpoints.
 The exporter refuses to overwrite an existing output directory.
-
-## Merge SFT and RL Weights
-
-Both inputs must already be Hugging Face safetensors checkpoints with the same architecture. `model_a` is the SFT
-checkpoint and receives weight `alpha`; `model_b` is the exported RL checkpoint and receives weight `1 - alpha`:
-
-```text
-theta_merged = alpha * theta_SFT + (1 - alpha) * theta_RL
-```
-
-For an equal interpolation:
-
-```bash
-python3 scripts/rl/linear_merge.py \
-  --model_a /path/to/MiLMMT-46-12B-v0.1 \
-  --model_b /path/to/experiment/merged_hf_step714 \
-  --alpha 0.5 \
-  --out /path/to/MiLMMT-46-12B-v1.0
-```
-
-The output follows the RL checkpoint's shard layout and metadata and includes `merge_manifest.json`. The script
-rejects `alpha` values outside `[0, 1]` and refuses to overwrite an existing output directory unless
-`--overwrite` is supplied.


### PR DESCRIPTION
- Split "Reinforcement Learning and Model Merging" into two parallel subsections (RL + Model Merging), matching the CPT/SFT structure.
- Add verl to the Training intro so all four stages are previewed.
- Point RL subsection to examples/rl.json and scripts/rl/README.md.
- Move linear_merge.py out of scripts/rl/ to scripts/ root, since it has no verl/reward-service dependencies and is a standalone stage script alongside cpt.sh and sft.sh.
- Move the merge usage docs into the script docstring and slim the root README's Model Merging section to a single command example, aligning its weight with the other Training subsections.
- Update scripts/rl/README.md title and file list to drop merging.